### PR TITLE
Specify encoding when opening files with Python 3

### DIFF
--- a/iso639/iso639.py
+++ b/iso639/iso639.py
@@ -36,12 +36,24 @@ def _fabtabular():
     #     import io
     #     data_fo = io.StringIO(urlopen('http://www-01.sil.org/iso639-3/iso-639-3.tab').read().decode())
     #     inverted_fo = io.StringIO(urlopen('http://www-01.sil.org/iso639-3/iso-639-3_Name_Index.tab').read().decode())
-    data_fo = open(data)
-    inverted_fo = open(inverted)
-    macro_fo = open(macro)
-    part5_fo = open(part5)
-    part2_fo = open(part2)
-    part1_fo = open(part1)
+
+    try:
+        # Python 3.x
+        data_fo = open(data, encoding='utf-8')
+        inverted_fo = open(inverted, encoding='utf-8')
+        macro_fo = open(macro, encoding='utf-8')
+        part5_fo = open(part5, encoding='utf-8')
+        part2_fo = open(part2, encoding='utf-8')
+        part1_fo = open(part1, encoding='utf-8')
+    except TypeError:
+        # Python 2.x
+        data_fo = open(data)
+        inverted_fo = open(inverted)
+        macro_fo = open(macro)
+        part5_fo = open(part5)
+        part2_fo = open(part2)
+        part1_fo = open(part1)
+
     with data_fo as u:
         with inverted_fo as i:
             with macro_fo as m:


### PR DESCRIPTION
I ran into `UnicodeDecodeError`s in some environments using Tox. The safest is probably to specify encoding when opening files with Python 3. 

Details:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:258: in get
    return getattr(self, key)[value]
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:125: in __getattr__
    'alpha2': self.part1,
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:98: in __get__
    val = self.f(instance)
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:191: in part1
    return dict((x.part1, x) for x in self.languages if x.part1)
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:98: in __get__
    val = self.f(instance)
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:167: in languages
    l, i, m, p5, p2, p1 = _fabtabular()
.tox/py34/lib/python3.4/site-packages/iso639/iso639.py:51: in _fabtabular
    return (list(csv.reader(u, delimiter='\t'))[1:],
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <encodings.ascii.IncrementalDecoder object at 0x10f0115c0>
input = b"Id\tPart2B\tPart2T\tPart1\tScope\tLanguage_Type\tRef_Name\tComment\r\naaa\t\t\t\tI\tL\tGhotuo\t\r\naab\t\t\t\tI\tL\t...arg\targ\targ\tan\tI\tL\tAragonese\t\r\narh\t\t\t\tI\tL\tArhuaco\t\r\nari\t\t\t\tI\tL\tArikara\t\r\narj\t\t\t\tI\tE\tA"
final = False

    def decode(self, input, final=False):
>       return codecs.ascii_decode(input, self.errors)[0]
E       UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 154: ordinal not in range(128)

.tox/py34/lib/python3.4/encodings/ascii.py:26: UnicodeDecodeError
```