### PR TITLE
Include tests in source distribution for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.py


### PR DESCRIPTION
OpenBSD relies on regression testing for ports and identifying dependency breakages. Having the test suite automatically rolled into the PyPI tarball would make this easier.