### PR TITLE
Use official OSI name in the license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author='Mikael Karlsson',
     author_email='i8myshoes@gmail.com',
     url='https://github.com/noumar/iso639',
-    license='AGPLv3',
+    license='AGPL-3.0',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     package_data={'': ['*.tab', '*.tsv']},
     zip_safe=False,


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.